### PR TITLE
Build statically linked binaries (#134)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ else
 	endif
 endif
 
-GO_BUILD_OPTIONS := -buildmode=${GO_BUILD_MODE} -ldflags "-s -X $(VERSION_VAR)=$(NMI_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE)"
+GO_BUILD_OPTIONS := -buildmode=${GO_BUILD_MODE} --tags "netgo osusergo" -ldflags "-s -X $(VERSION_VAR)=$(NMI_VERSION) -X $(GIT_VAR)=$(GIT_HASH) -X $(BUILD_DATE_VAR)=$(BUILD_DATE) -extldflags '-static'"
 E2E_TEST_OPTIONS := -count=1 -v
 
 # useful for other docker repos
@@ -54,16 +54,20 @@ clean:
 	rm -rf bin/$(PROJECT_NAME)
 
 build-nmi:clean-nmi
-	GOOS=linux GOARCH=amd64 go build -o bin/$(PROJECT_NAME)/$(NMI_BINARY_NAME) $(GO_BUILD_OPTIONS) github.com/Azure/$(PROJECT_NAME)/cmd/$(NMI_BINARY_NAME)
+	PKG_NAME=github.com/Azure/$(PROJECT_NAME)/cmd/$(NMI_BINARY_NAME) $(MAKE) bin/$(PROJECT_NAME)/$(NMI_BINARY_NAME)
 
 build-mic:clean-mic
-	GOOS=linux GOARCH=amd64 go build -o bin/$(PROJECT_NAME)/$(MIC_BINARY_NAME) $(GO_BUILD_OPTIONS) github.com/Azure/$(PROJECT_NAME)/cmd/$(MIC_BINARY_NAME)
+	PKG_NAME=github.com/Azure/$(PROJECT_NAME)/cmd/$(MIC_BINARY_NAME) $(MAKE) bin/$(PROJECT_NAME)/$(MIC_BINARY_NAME)
 
+build-demo: build_tags := netgo osusergo
 build-demo:clean-demo
-	GOOS=linux GOARCH=amd64 go build -o bin/$(PROJECT_NAME)/$(DEMO_BINARY_NAME) $(GO_BUILD_OPTIONS) github.com/Azure/$(PROJECT_NAME)/cmd/$(DEMO_BINARY_NAME)
+	PKG_NAME=github.com/Azure/$(PROJECT_NAME)/cmd/$(DEMO_BINARY_NAME) ${MAKE} bin/$(PROJECT_NAME)/$(DEMO_BINARY_NAME)
+
+bin/%:
+	GOOS=linux GOARCH=amd64 go build $(GO_BUILD_OPTIONS) -o "$(@)" "$(PKG_NAME)"
 
 build-identity-validator:clean-identity-validator
-	GOOS=linux GOARCH=amd64 go build -o bin/$(PROJECT_NAME)/$(IDENTITY_VALIDATOR_BINARY_NAME) $(GO_BUILD_OPTIONS) github.com/Azure/$(PROJECT_NAME)/test/e2e/$(IDENTITY_VALIDATOR_BINARY_NAME)
+	PKG_NAME=github.com/Azure/$(PROJECT_NAME)/test/e2e/$(IDENTITY_VALIDATOR_BINARY_NAME) $(MAKE) bin/$(PROJECT_NAME)/$(IDENTITY_VALIDATOR_BINARY_NAME)
 
 build:clean build-nmi build-mic build-demo build-identity-validator
 


### PR DESCRIPTION
Ensures that these binaries work regardless of what libraries they were
linked to at build time... e.g. build on Ubuntu (with glibc) and run on
Alpine (musl libc).

The main thing here is that if you import the `net` or the `archive/tar` packages
go will automatically switch from the defaul statically linked build to a
dynamically linked one.